### PR TITLE
HHTD-179 Create docsplit_processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # DocsplitProcessor
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/docsplit_processor`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This gem provides a custom processor for use with the paperclip gem. The processor converts `doc` and `docx` documents to `pdf` using the docsplit gem.
 
 ## Installation
 
@@ -24,6 +22,15 @@ Or install it yourself as:
 
 TODO: Write usage instructions here
 
+To use the processor, add it to the `styles` option where paperclip is being used. For example,
+
+``` ruby
+  has_attached_file :cv,
+    path: PAPERCLIP_PATH,
+    styles: { pdf: {  format: :pdf } },
+    processors: [:docsplit_processor]
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -32,7 +39,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/docsplit_processor.
+Bug reports and pull requests are welcome on GitHub at https://github.com/hiring-hub/docsplit_processor.
 
 ## License
 

--- a/docsplit_processor.gemspec
+++ b/docsplit_processor.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "docsplit_processor/version"
@@ -9,9 +8,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Tim Millar"]
   spec.email         = ["heteroskedasticity99@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{paperclip processor for the docsplit gem}
+  spec.description   = %q{paperclip processor for the docsplit gem}
+  spec.homepage      = "https://github.com/hiring-hub/docsplit_processor"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -30,7 +29,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "paperclip"
+  spec.add_dependency 'docsplit'
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'activerecord', '>= 4.2.0'
+  spec.add_development_dependency 'activesupport', '>= 4.2.0'
 end

--- a/lib/docsplit_processor.rb
+++ b/lib/docsplit_processor.rb
@@ -1,5 +1,5 @@
-require "docsplit_processor/version"
+require 'docsplit_processor/version'
+require 'docsplit_processor/paperclip/pdf_extractor'
 
 module DocsplitProcessor
-  # Your code goes here...
 end

--- a/lib/docsplit_processor/paperclip/pdf_extractor.rb
+++ b/lib/docsplit_processor/paperclip/pdf_extractor.rb
@@ -1,0 +1,43 @@
+require 'paperclip'
+require 'docsplit'
+
+module Paperclip
+  class PdfExtractor < Processor
+    def make
+      if original_cv_is_pdf?
+        File.open(input_file_path)
+      else
+        Docsplit.extract_pdf(input_file_path, output: destination_dir)
+        File.open(output_file_path)
+      end
+    rescue StandardError
+      raise Paperclip::Error, "Error converting '#{input_file_path}' to pdf"
+    end
+
+    private
+
+    def original_cv_is_pdf?
+      input_file_path.match(/pdf$/)
+    end
+
+    def input_file_path
+      file.path
+    end
+
+    def destination_dir
+      File.dirname(input_file_path)
+    end
+
+    def output_file_path
+      "#{destination_dir}/#{output_base_name}"
+    end
+
+    def output_base_name
+      "#{input_base_name}.pdf"
+    end
+
+    def input_base_name
+      File.basename(input_file_path, '.*')
+    end
+  end
+end

--- a/spec/docsplit_processor/paperclip/pdf_extractor_spec.rb
+++ b/spec/docsplit_processor/paperclip/pdf_extractor_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+module Paperclip
+  RSpec.describe PdfExtractor do
+    describe '#make' do
+      subject { PdfExtractor.new(file, output: dir).make }
+
+      let(:file) { double('File', path: file_path) }
+      let(:file_path) { "#{dir}/test.docx" }
+      let(:pdf_path) { "#{dir}/test.pdf" }
+      let(:dir) { './temp_dir' }
+
+      before do
+        allow(Docsplit).to receive(:extract_pdf).with(file_path, output: dir)
+        allow(File).to receive(:open).with(pdf_path)
+      end
+
+      it 'converts any format files to pdfs' do
+        expect(Docsplit).to receive(:extract_pdf).with(file_path, output: dir)
+
+        subject
+      end
+
+      it 'returns a file' do
+        expect(File).to receive(:open).with(pdf_path)
+
+        subject
+      end
+
+      context 'when the CV is already a pdf' do
+        let(:file_path) { "#{dir}/test.pdf" }
+
+        it 'returns the original document' do
+          expect(File).to receive(:open).with(file_path)
+
+          subject
+        end
+
+        it 'does not process the document with docsplit' do
+          expect(Docsplit).not_to receive(:extract_pdf).with(any_args)
+
+          subject
+        end
+      end
+
+      context 'when docsplit fails' do
+        before do
+          allow(Docsplit).to receive(:extract_pdf)
+            .with(file_path, output: dir).and_raise(StandardError)
+        end
+
+        it 'raises a paperclip error' do
+          expect { subject }.to raise_error(Paperclip::Error)
+        end
+      end
+    end
+  end
+end

--- a/spec/docsplit_processor_spec.rb
+++ b/spec/docsplit_processor_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe DocsplitProcessor do
-  it "has a version number" do
+  it 'has a version number' do
     expect(DocsplitProcessor::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require 'active_support/core_ext/module'
 require "docsplit_processor"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Initial PR for gem. The gem provides a custom processor for paperclip, which converts doc and docx files into pdfs, using the docsplit gem. This is needed so that candidate CVs can be easily previewed in the browser.

![](https://media2.giphy.com/media/JfDNFU1qOZna/giphy.gif)
