### PR TITLE
Close temporary files opened by extractor

### DIFF
--- a/lib/docsplit_processor/paperclip/pdf_extractor.rb
+++ b/lib/docsplit_processor/paperclip/pdf_extractor.rb
@@ -5,13 +5,16 @@ module Paperclip
   class PdfExtractor < Processor
     def make
       if original_cv_is_pdf?
-        File.open(input_file_path)
+        file = File.open(input_file_path)
+        file
       else
         Docsplit.extract_pdf(input_file_path, output: destination_dir)
-        File.open(output_file_path)
+        file = File.open(output_file_path)
+        file
       end
     rescue StandardError
       raise Paperclip::Error, "Error converting '#{input_file_path}' to pdf"
+      file.close
     end
 
     private


### PR DESCRIPTION
At present we are seeing errors when using this gem whereby too many files are left open by paperclip and the rake process calling them eventually runs out of memory and dies. A possible cause is that in the pdf extractor paperclip is using, when we encounter an error we rescue it but we dont close the temporary file we opened. This change closes the file inside the rescue.