### PR TITLE
Close open files before raise

### DIFF
--- a/lib/docsplit_processor/paperclip/pdf_extractor.rb
+++ b/lib/docsplit_processor/paperclip/pdf_extractor.rb
@@ -5,16 +5,14 @@ module Paperclip
   class PdfExtractor < Processor
     def make
       if original_cv_is_pdf?
-        file = File.open(input_file_path)
-        file
+        File.open(input_file_path)
       else
         Docsplit.extract_pdf(input_file_path, output: destination_dir)
-        file = File.open(output_file_path)
-        file
+        File.open(output_file_path)
       end
     rescue StandardError
+      file.close!
       raise Paperclip::Error, "Error converting '#{input_file_path}' to pdf"
-      file.close
     end
 
     private

--- a/lib/docsplit_processor/version.rb
+++ b/lib/docsplit_processor/version.rb
@@ -1,3 +1,3 @@
 module DocsplitProcessor
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/docsplit_processor/paperclip/pdf_extractor_spec.rb
+++ b/spec/docsplit_processor/paperclip/pdf_extractor_spec.rb
@@ -5,7 +5,7 @@ module Paperclip
     describe '#make' do
       subject { PdfExtractor.new(file, output: dir).make }
 
-      let(:file) { double('File', path: file_path) }
+      let(:file) { double('File', path: file_path, close!: nil) }
       let(:file_path) { "#{dir}/test.docx" }
       let(:pdf_path) { "#{dir}/test.pdf" }
       let(:dir) { './temp_dir' }
@@ -49,7 +49,8 @@ module Paperclip
             .with(file_path, output: dir).and_raise(StandardError)
         end
 
-        it 'raises a paperclip error' do
+        it 'closes the file and raises a paperclip error' do
+          expect(file).to receive(:close!)
           expect { subject }.to raise_error(Paperclip::Error)
         end
       end


### PR DESCRIPTION
at present the paperclip tempfile is being closed after raising an error, where the code will never be reached. this change closes the tempfile before the raise.