### PR TITLE
Better paperclip errors

### DIFF
--- a/lib/docsplit_processor/paperclip/pdf_extractor.rb
+++ b/lib/docsplit_processor/paperclip/pdf_extractor.rb
@@ -10,9 +10,10 @@ module Paperclip
         Docsplit.extract_pdf(input_file_path, output: destination_dir)
         File.open(output_file_path)
       end
-    rescue StandardError
+    rescue StandardError => exception
+      input_file_path = input_file_path
       file.close!
-      raise Paperclip::Error, "Error converting '#{input_file_path}' to pdf"
+      raise Paperclip::Error, "Error converting '#{input_file_path}' to pdf\nError caught: #{exception.backtrace.join('\n')}"
     end
 
     private

--- a/lib/docsplit_processor/version.rb
+++ b/lib/docsplit_processor/version.rb
@@ -1,3 +1,3 @@
 module DocsplitProcessor
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
At present when the process converting files to pdfs fails, we are closing the tempfile, then raising an error. Since the file has been closed we can no longer use it in our logs. This change includes a work around and also logs the exception's backtrace to stdout.